### PR TITLE
Depend on a version of puppetlabs/mysql that exists

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 2.3.1"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Currently running `puppet module install shoekstra-owncloud` fails because puppetlabs-mysql 3.0.0 is not released on puppet forge. The latest version on the puppet forge is 2.3.1.

Since this module does not appear to depend on any new functionality in the git master branch of puppetlabs-mysql, this change should be safe to make.
