### PR TITLE
Specify the path when executing /usr/bin/test

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,7 +28,7 @@ class owncloud::config inherits owncloud {
   }
 
   exec { "mkdir -p ${datadirectory}":
-    path   => '/bin',
+    path   => ['/bin', '/usr/bin'],
     unless => "test -d ${datadirectory}"
   } ->
 

--- a/spec/classes/owncloud_spec.rb
+++ b/spec/classes/owncloud_spec.rb
@@ -146,7 +146,7 @@ describe 'owncloud', :type => :class do
     context 'when $datadirectory is /var/www/owncloud/data' do
       it { should contain_exec('mkdir -p /var/www/owncloud/data').with(
         {
-          'path'   => '/bin',
+          'path'   => ['/bin', '/usr/bin'],
           'unless' => 'test -d /var/www/owncloud/data'
         }
       )}


### PR DESCRIPTION
This module doesn't work on my ubuntu 14.04 installation because puppet tries to run `/bin/test`, but the `test` binary is installed to `/usr/bin/test` on all linux systems I have been able to find.

I attempted to run the acceptance tests as per `CONTRIBUTING.md` but I couldn't get them to work at all before my changes, so I have not added an acceptance test for this change.

If you're using this on a system that puts the `test` binary under `/bin` (not sure whether one exists) then `config.pp` will have to be modified to add `/usr/bin` to the `path` parameter instead of fully qualifying the `unless` parameter.
