### PR TITLE
Install owncloud-server instead of owncloud (remove apache dependency)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class owncloud::params {
         'Debian', 'Ubuntu': {
           $datadirectory = '/var/www/owncloud/data'
           $documentroot  = '/var/www/owncloud'
-          $package_name  = 'owncloud'
+          $package_name  = 'owncloud-server'
           $www_user      = 'www-data'
           $www_group     = 'www-data'
 
@@ -34,7 +34,7 @@ class owncloud::params {
         'Centos', 'Fedora': {
           $datadirectory = '/var/www/html/owncloud/data'
           $documentroot  = '/var/www/html/owncloud'
-          $package_name  = 'owncloud'
+          $package_name  = 'owncloud-server'
           $www_user      = 'apache'
           $www_group     = 'apache'
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -25,7 +25,7 @@ describe 'owncloud class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe package('owncloud') do
+    describe package('owncloud-server') do
       it { is_expected.to be_installed }
     end
   end

--- a/spec/classes/owncloud_spec.rb
+++ b/spec/classes/owncloud_spec.rb
@@ -79,12 +79,12 @@ describe 'owncloud' do
             is_expected.to contain_class('owncloud::config').that_comes_before('owncloud')
             is_expected.to contain_class('owncloud')
 
-            is_expected.to contain_package('owncloud').with_ensure('present')
+            is_expected.to contain_package('owncloud-server').with_ensure('present')
           end
 
           # owncloud::install
 
-          it 'should include classes to manage repo, install owncloud repo and install owncloud package' do
+          it 'should include classes to manage repo, install owncloud repo and install owncloud-server package' do
             case facts[:osfamily]
             when 'Debian'
               is_expected.to contain_class('apt')
@@ -102,12 +102,12 @@ describe 'owncloud' do
                   },
                   release: ' ',
                   repos: '/'
-                ).that_comes_before('Package[owncloud]')
+                ).that_comes_before('Package[owncloud-server]')
               when 'Ubuntu'
                 if facts[:lsbdistcodename] == 'precise'
-                  is_expected.to contain_apt__ppa('ppa:ondrej/php5-oldstable').that_comes_before('Package[owncloud]')
+                  is_expected.to contain_apt__ppa('ppa:ondrej/php5-oldstable').that_comes_before('Package[owncloud-server]')
                 else
-                  is_expected.not_to contain_apt__ppa('ppa:ondrej/php5-oldstable').that_comes_before('Package[owncloud]')
+                  is_expected.not_to contain_apt__ppa('ppa:ondrej/php5-oldstable').that_comes_before('Package[owncloud-server]')
                 end
 
                 is_expected.to contain_apt__source('owncloud').with(
@@ -118,7 +118,7 @@ describe 'owncloud' do
                   },
                   release: ' ',
                   repos: '/'
-                ).that_comes_before('Package[owncloud]')
+                ).that_comes_before('Package[owncloud-server]')
               end
             when 'RedHat'
               is_expected.not_to contain_class('apt')
@@ -138,7 +138,7 @@ describe 'owncloud' do
                     gpgcheck: 1,
                     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
                     enabled: 1
-                  ).that_comes_before('Package[owncloud]').that_requires('Class[remi]')
+                  ).that_comes_before('Package[owncloud-server]').that_requires('Class[remi]')
                 else
                   is_expected.not_to contain_class('remi')
                   is_expected.not_to contain_yumrepo('remi-php56')
@@ -152,7 +152,7 @@ describe 'owncloud' do
                   gpgcheck: 1,
                   gpgkey: "http://download.opensuse.org/repositories/isv:/ownCloud:/community/CentOS_CentOS-#{facts[:operatingsystemmajrelease]}/repodata/repomd.xml.key",
                   enabled: 1
-                ).that_comes_before('Package[owncloud]')
+                ).that_comes_before('Package[owncloud-server]')
               when 'Fedora'
                 is_expected.not_to contain_class('epel')
 
@@ -164,11 +164,11 @@ describe 'owncloud' do
                   gpgcheck: 1,
                   gpgkey: "http://download.opensuse.org/repositories/isv:/ownCloud:/community/Fedora_#{facts[:operatingsystemmajrelease]}/repodata/repomd.xml.key",
                   enabled: 1
-                ).that_comes_before('Package[owncloud]')
+                ).that_comes_before('Package[owncloud-server]')
               end
             end
 
-            is_expected.to contain_package('owncloud').with_ensure('present')
+            is_expected.to contain_package('owncloud-server').with_ensure('present')
           end
 
           # owncloud::apache
@@ -408,7 +408,7 @@ describe 'owncloud' do
         }
       end
 
-      it { expect { is_expected.to contain_package('owncloud') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+      it { expect { is_expected.to contain_package('owncloud-server') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
 end


### PR DESCRIPTION
The package `owncloud` depends on apache. Since i want to use this module with nginx i am supposed to write in my manifest:

```
class { '::owncloud':
  manage_apache => false,
  manage_vhost  => false,
  datadirectory => '/var/www/cloud.myprecise.box',
  db_host => 'localhost',
  db_name => 'owncloud',
  db_user => 'owncloud',
  db_pass => 'p4ssw0rd',
}
```

What i get is a non-working machine since nginx and apache compete to bind on the 80 port. The solution is to replace the `owncloud` package with `owncloud-server` (no apache dep)