### PR TITLE
Feature: manage package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Option to disable OS package management
+
 ## 0.5.2  (2016-03-23)
 
 - Added option to specify admin credentials ([#27](https://github.com/shoekstra/puppet-owncloud/pull/27))

--- a/README.markdown
+++ b/README.markdown
@@ -250,6 +250,10 @@ Set to true for the module to install Apache using the [PuppetLabs Apache module
 
 Set to true for the module to create the database and database user for you, using the `db_name`, `db_user`, `db_pass` and `db_type` values. Enabling this will not install the database server, this must be done separately. Defaults to 'true'.
 
+##### `manage_package`
+
+When set to true, the module will install the owncloud software via your system's package manager. Set to false, you're on your own. This is mostly useful if you plan on installing the package yourself prior to using this module.
+
 ##### `manage_phpmysql`
 
 Set to true for the module to install the PHP MySQL bindings using the [PuppetLabs MySQL module](https://github.com/puppetlabs/puppetlabs-mysql); this is required on some distributions until the package is installed by the ownCloud package. Defaults to 'true'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class owncloud (
   $https_port      = 443,
   $manage_apache   = true,
   $manage_db       = true,
+  $manage_package  = true,
   $manage_phpmysql = true,
   $manage_repo     = true,
   $manage_skeleton = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class owncloud (
 
   validate_bool($manage_apache)
   validate_bool($manage_db)
+  validate_bool($manage_package)
   validate_bool($manage_repo)
   validate_bool($manage_skeleton)
   validate_bool($manage_vhost)
@@ -44,6 +45,12 @@ class owncloud (
 
     if $ssl_ca { validate_absolute_path($ssl_ca) }
     if $ssl_chain { validate_absolute_path($ssl_chain) }
+  }
+
+  # If we're not managing the package, we probably don't need to
+  # manage the repository
+  unless $manage_package {
+    $manage_repo = false
   }
 
   class { '::owncloud::install': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class owncloud (
   $manage_db       = true,
   $manage_package  = true,
   $manage_phpmysql = true,
-  $manage_repo     = $manage_package,
+  $manage_repo     = pick($manage_package, true),
   $manage_skeleton = true,
   $manage_vhost    = true,
   $ssl             = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class owncloud (
   $manage_db       = true,
   $manage_package  = true,
   $manage_phpmysql = true,
-  $manage_repo     = true,
+  $manage_repo     = $manage_package,
   $manage_skeleton = true,
   $manage_vhost    = true,
   $ssl             = false,
@@ -45,12 +45,6 @@ class owncloud (
 
     if $ssl_ca { validate_absolute_path($ssl_ca) }
     if $ssl_chain { validate_absolute_path($ssl_chain) }
-  }
-
-  # If we're not managing the package, we probably don't need to
-  # manage the repository
-  unless $manage_package {
-    $manage_repo = false
   }
 
   class { '::owncloud::install': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -74,9 +74,15 @@ class owncloud::install {
   }
 
   if $::owncloud::manage_phpmysql {
-    class { '::mysql::bindings':
-      php_enable => true,
-      before     => Package[$::owncloud::package_name],
+    if $::owncloud::manage_package {
+      class { '::mysql::bindings':
+        php_enable => true,
+        before     => Package[$::owncloud::package_name],
+      }
+    } else {
+      class { '::mysql::bindings':
+        php_enable => true,
+      }
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -80,7 +80,9 @@ class owncloud::install {
     }
   }
 
-  package { $::owncloud::package_name:
-    ensure => present,
+  if $::owncloud::manage_package {
+    package { $::owncloud::package_name:
+      ensure => present,
+    }
   }
 }


### PR DESCRIPTION
Allowing a user to decline the installation of the owncloud packages. This is pretty typical across puppet modules. Choosing to not install the package via `manage_package = false` also sets `manage_repo` to `false` for simplicity.
